### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,14 +54,14 @@ jobs:
     steps:
       - id: "auth"
         name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v0"
+        uses: "google-github-actions/auth@v1.1.1"
         with:
           workload_identity_provider: "projects/847955048569/locations/global/workloadIdentityPools/my-pool/providers/my-provider"
           service_account: "my-service-account@handleit-349522.iam.gserviceaccount.com"
           token_format: "access_token"
 
       - id: "deploy"
-        uses: "google-github-actions/deploy-cloudrun@v0"
+        uses: "google-github-actions/deploy-cloudrun@v1.0.2"
         with:
           service: "handle-it-server"
           image: "gcr.io/handleit-349522/handle-it-server:latest"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,10 @@ jobs:
           database: test
           port: 5432
 
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.0.0
 
       - name: Setup Nodejs
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3.8.1
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v3.8.1](https://github.com/actions/setup-node/releases/tag/v3.8.1)** on 2023-08-17T13:14:07Z
* **[google-github-actions/auth](https://github.com/google-github-actions/auth)** published a new release **[v1.1.1](https://github.com/google-github-actions/auth/releases/tag/v1.1.1)** on 2023-05-08T18:19:27Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.0.0](https://github.com/actions/checkout/releases/tag/v4.0.0)** on 2023-09-04T12:22:57Z
* **[google-github-actions/deploy-cloudrun](https://github.com/google-github-actions/deploy-cloudrun)** published a new release **[v1.0.2](https://github.com/google-github-actions/deploy-cloudrun/releases/tag/v1.0.2)** on 2023-05-08T18:19:36Z
