### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,10 @@ jobs:
           database: test
           port: 5432
 
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.1
 
       - name: Setup Nodejs
-        uses: actions/setup-node@v3.8.1
+        uses: actions/setup-node@v4.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -52,7 +52,7 @@ jobs:
     needs: test
     if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.1
 
       - name: "Authenticate to Google Cloud"
         uses: "google-github-actions/auth@v1.1.1"

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.0](https://github.com/actions/setup-node/releases/tag/v4.0.0)** on 2023-10-23T14:55:24Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
