### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,17 +11,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: ikalnytskyi/action-setup-postgres@v4
+      - uses: ikalnytskyi/action-setup-postgres@v5
         with:
           username: postgres
           password: postgres
           database: test
           port: 5432
 
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.1
 
       - name: Setup Nodejs
-        uses: actions/setup-node@v3.8.1
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -52,7 +52,7 @@ jobs:
     needs: test
     if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.1
 
       - name: "Authenticate to Google Cloud"
         uses: "google-github-actions/auth@v1.1.1"

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[google-github-actions/auth](https://github.com/google-github-actions/auth)** published a new release **[v2.1.2](https://github.com/google-github-actions/auth/releases/tag/v2.1.2)** on 2024-02-25T19:44:35Z
* **[ikalnytskyi/action-setup-postgres](https://github.com/ikalnytskyi/action-setup-postgres)** published a new release **[v5](https://github.com/ikalnytskyi/action-setup-postgres/releases/tag/v5)** on 2024-01-09T23:27:30Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.2](https://github.com/actions/setup-node/releases/tag/v4.0.2)** on 2024-02-07T04:51:19Z
* **[google-github-actions/deploy-cloudrun](https://github.com/google-github-actions/deploy-cloudrun)** published a new release **[v2.3.0](https://github.com/google-github-actions/deploy-cloudrun/releases/tag/v2.3.0)** on 2024-03-28T18:49:07Z
